### PR TITLE
Remove sign comparison errors when compiling with g++

### DIFF
--- a/src/forthy2/cx.hpp
+++ b/src/forthy2/cx.hpp
@@ -590,7 +590,7 @@ namespace forthy2 {
   }
 
   inline Node<Op> &RestackOp::eval(Cx &cx) {
-    if (cx.stack->len() < in_len) {
+    if (in_len < 0 || cx.stack->len() < static_cast<size_t>(in_len)) {
       throw ESys(form.pos, "Nothing to restack: ", *cx.stack);
     }
     

--- a/src/forthy2/ops/peek.hpp
+++ b/src/forthy2/ops/peek.hpp
@@ -8,7 +8,7 @@ namespace forthy2 {
   
   struct PeekOp: Op {
     bool alt_src;
-    int offs;
+    size_t offs;
     
     PeekOp(Form &form, Node<Op> &prev, bool alt_src, int offs = 0);
     void dealloc(Cx &cx) override;


### PR DESCRIPTION
I lack clang on my development machine. When compiling with GCC, I got a number of errors due to comparing signed and unsigned integers. The two fixes in this PR address those issues by changing the sign of the peek offset, and by doing an explicit signed comparison in another instance.